### PR TITLE
feat: make pip_to_rez_package_name lowercase

### DIFF
--- a/src/rez/utils/pip.py
+++ b/src/rez/utils/pip.py
@@ -39,7 +39,7 @@ def pip_to_rez_package_name(dist_name):
     Returns:
         str: Rez-compatible package name.
     """
-    return dist_name.replace("-", "_")
+    return dist_name.replace("-", "_").lower()
 
 
 def pip_to_rez_version(dist_version, allow_legacy=True):


### PR DESCRIPTION
Because some packages change their case depending on the version, resulting in errors when running rez pip for multiple python versions.